### PR TITLE
Remove PageId from post-related classes and logic

### DIFF
--- a/src/HolaViaje.Social/Data/Migrations/20250224004643_AddPostEntity.cs
+++ b/src/HolaViaje.Social/Data/Migrations/20250224004643_AddPostEntity.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Microsoft.EntityFrameworkCore.Migrations;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
@@ -23,7 +22,6 @@ namespace HolaViaje.Social.Data.Migrations
                     Content = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: true),
                     IsHtmlContent = table.Column<bool>(type: "boolean", nullable: false),
                     UserId = table.Column<long>(type: "bigint", nullable: false),
-                    PageId = table.Column<int>(type: "integer", nullable: false),
                     Visibility = table.Column<int>(type: "integer", nullable: false),
                     Country = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
                     State = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),

--- a/src/HolaViaje.Social/Data/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/src/HolaViaje.Social/Data/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -43,9 +43,6 @@ namespace HolaViaje.Social.Data.Migrations
                     b.Property<bool>("IsHtmlContent")
                         .HasColumnType("boolean");
 
-                    b.Property<int>("PageId")
-                        .HasColumnType("integer");
-
                     b.Property<int>("Status")
                         .HasColumnType("integer");
 

--- a/src/HolaViaje.Social/Features/Posts/Models/PostModel.cs
+++ b/src/HolaViaje.Social/Features/Posts/Models/PostModel.cs
@@ -7,10 +7,6 @@ public class PostModel : PostBasicModel
     /// </summary>
     public PostType Type { get; set; } = PostType.Short;
     /// <summary>
-    /// Gets or sets the page identifier.
-    /// </summary>
-    public int PageId { get; set; } = 0;
-    /// <summary>
     /// Gets or sets if the post is a draft.
     /// </summary>
     public bool IsDraft { get; set; }

--- a/src/HolaViaje.Social/Features/Posts/Post.cs
+++ b/src/HolaViaje.Social/Features/Posts/Post.cs
@@ -13,11 +13,10 @@ public class Post : EntityBase
         };
     }
 
-    public Post(long userId, int pageId)
+    public Post(long userId)
         : this()
     {
         UserId = userId;
-        PageId = pageId;
     }
 
     /// <summary>
@@ -44,10 +43,6 @@ public class Post : EntityBase
     /// Gets or sets the user identifier.
     /// </summary>
     public long UserId { get; set; }
-    /// <summary>
-    /// Gets or sets the page identifier.
-    /// </summary>
-    public int PageId { get; set; } = 0;
     /// <summary>
     /// Gets or sets the visibility settings of the post.
     /// </summary>
@@ -190,12 +185,6 @@ public class Post : EntityBase
     /// <param name="userId">User Identifier.</param>
     /// <returns>True if is the owner, else false.</returns>
     public bool IsOwner(long userId) => UserId == userId;
-
-    /// <summary>
-    /// Determines whether the post is associated with a page.
-    /// </summary>
-    /// <returns></returns>
-    public bool IsAssociatedWithPage() => PageId > 0;
 
     /// <summary>
     /// Gets if the post can add a media file.

--- a/src/HolaViaje.Social/Features/Posts/PostController.cs
+++ b/src/HolaViaje.Social/Features/Posts/PostController.cs
@@ -132,12 +132,12 @@ public class PostController(IPostApplication postApplication) : ControllerCore
     }
 
     [Authorize]
-    [HttpDelete("{postId}/")]
+    [HttpDelete("{postId}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ErrorModel), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<IActionResult> DeleteAsyn(long postId, CancellationToken cancellationToken = default)
+    public async Task<IActionResult> DeleteAsync(long postId, CancellationToken cancellationToken = default)
     {
         var result = await postApplication.DeleteAsync(postId, UserIdentity, cancellationToken);
 

--- a/src/HolaViaje.Social/Features/Posts/PostErrorModelHelper.cs
+++ b/src/HolaViaje.Social/Features/Posts/PostErrorModelHelper.cs
@@ -4,11 +4,11 @@ namespace HolaViaje.Social.Features.Posts;
 
 public static class PostErrorModelHelper
 {
-    public static ErrorModel ErrorPublishOnPage() => new(400, "You don't have permission to post on this page.");
-    public static ErrorModel ErrorUpdatePost() => new(400, "You don't have permission to update this post.");
-    public static ErrorModel ErrorPostNotFound() => new(400, "Post not found.");
-    public static ErrorModel ErrorUploadsPending() => new(400, "The're some uploads pending, complete the uploads or remove the files first.");
-    public static ErrorModel ErrorMediaFileNotFound() => new(400, "Post not found.");
-    public static ErrorModel ErrorMaxFilesQuantityReached() => new(400, "The maximum number of files has been reached.");
-    public static ErrorModel ErrorAccessDenied() => new ErrorModel(403, "You can't access to the this post.");
+    public static ErrorModel PublishPermissionError() => new(400, "You don't have permission to post on this page.");
+    public static ErrorModel UpdatePostPermissionError() => new(400, "You don't have permission to update this post.");
+    public static ErrorModel PostNotFoundError() => new(400, "Post not found.");
+    public static ErrorModel UploadsPendingError() => new(400, "The're some uploads pending, complete the uploads or remove the files first.");
+    public static ErrorModel MediaFileNotFoundError() => new(400, "Post not found.");
+    public static ErrorModel MaxFilesQuantityReachedError() => new(400, "The maximum number of files has been reached.");
+    public static ErrorModel AccessDeniedError() => new ErrorModel(403, "You can't access to the this post.");
 }

--- a/test/HolaViaje.Social.Tests/Features/Posts/PostApplicationTests.cs
+++ b/test/HolaViaje.Social.Tests/Features/Posts/PostApplicationTests.cs
@@ -29,21 +29,11 @@ namespace HolaViaje.Social.Tests.Features.Posts
         }
 
         [TestMethod]
-        public async Task CreateAsync_ShouldReturnError_WhenPageIdIsGreaterThanZero()
-        {
-            var model = new PostModel { PageId = 1 };
-            var result = await _postApplication.CreateAsync(model, 1);
-
-            Assert.IsTrue(result.IsT1);
-            Assert.AreEqual(PostErrorModelHelper.ErrorPublishOnPage(), result.AsT1);
-        }
-
-        [TestMethod]
         public async Task CreateAsync_ShouldReturnPostViewModel()
         {
             // Arrange
             var postModel = new PostModel { Content = "Test content", Type = PostType.Event, Visibility = Visibility.Public };
-            var post = new Post(1, 0) { Content = "Test content", Type = PostType.Event, Visibility = Visibility.Public };
+            var post = new Post(1) { Content = "Test content", Type = PostType.Event, Visibility = Visibility.Public };
             var postViewModel = new PostViewModel { Content = "Test content", Type = PostType.Event, Visibility = Visibility.Public, Control = new() };
 
             _postRepositoryMock.Setup(repo => repo.CreateAsync(It.IsAny<Post>(), It.IsAny<CancellationToken>())).ReturnsAsync(post);
@@ -65,7 +55,7 @@ namespace HolaViaje.Social.Tests.Features.Posts
             var result = await _postApplication.UpdateAsync(1, new PostBasicModel(), 1);
 
             Assert.IsTrue(result.IsT1);
-            Assert.AreEqual(PostErrorModelHelper.ErrorPostNotFound(), result.AsT1);
+            Assert.AreEqual(PostErrorModelHelper.PostNotFoundError(), result.AsT1);
         }
 
         [TestMethod]
@@ -73,7 +63,7 @@ namespace HolaViaje.Social.Tests.Features.Posts
         {
             // Arrange
             var postBasicModel = new PostBasicModel { Content = "Updated content", Visibility = Visibility.Public };
-            var post = new Post(1, 0) { Content = "Test content", Type = PostType.Event, Visibility = Visibility.Public };
+            var post = new Post(1) { Content = "Test content", Type = PostType.Event, Visibility = Visibility.Public };
             var postViewModel = new PostViewModel { Content = "Updated content", Type = PostType.Event, Visibility = Visibility.Public, Control = new() };
 
             _postRepositoryMock.Setup(repo => repo.GetAsync(It.IsAny<long>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(post);
@@ -96,14 +86,14 @@ namespace HolaViaje.Social.Tests.Features.Posts
             var result = await _postApplication.PublishAsync(1, 1);
 
             Assert.IsTrue(result.IsT1);
-            Assert.AreEqual(PostErrorModelHelper.ErrorPostNotFound(), result.AsT1);
+            Assert.AreEqual(PostErrorModelHelper.PostNotFoundError(), result.AsT1);
         }
 
         [TestMethod]
         public async Task PublishAsync_ShouldReturnPostViewModel()
         {
             // Arrange
-            var post = new Post(1, 0) { Content = "Test content", Type = PostType.Event, Visibility = Visibility.Public };
+            var post = new Post(1) { Content = "Test content", Type = PostType.Event, Visibility = Visibility.Public };
             var postViewModel = new PostViewModel { Content = "Test content", Type = PostType.Event, Visibility = Visibility.Public, Control = new() };
 
             _postRepositoryMock.Setup(repo => repo.GetAsync(It.IsAny<long>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(post);
@@ -126,7 +116,7 @@ namespace HolaViaje.Social.Tests.Features.Posts
             var result = await _postApplication.CreateUploadLinkAsync(1, new UploadLinkModel("hello.png", 1024), 1);
 
             Assert.IsTrue(result.IsT1);
-            Assert.AreEqual(PostErrorModelHelper.ErrorPostNotFound(), result.AsT1);
+            Assert.AreEqual(PostErrorModelHelper.PostNotFoundError(), result.AsT1);
         }
 
         [TestMethod]
@@ -135,7 +125,7 @@ namespace HolaViaje.Social.Tests.Features.Posts
             // Arrange
             var userId = 1;
             var uploadLinkModel = new UploadLinkModel("hello.png", 1024);
-            var post = new Post(userId, 0) { Content = "Test content", Type = PostType.Event, Visibility = Visibility.Public };
+            var post = new Post(userId) { Content = "Test content", Type = PostType.Event, Visibility = Visibility.Public };
             var mediaFileModel = new MediaFileModel("test123", "test.jpg", "application/jpg", "localhost", false);
             var blobLinkModel = new BlobLinkModel("test123", "test.jpg", DateTimeOffset.Now.AddDays(1));
 
@@ -160,14 +150,14 @@ namespace HolaViaje.Social.Tests.Features.Posts
             var result = await _postApplication.MarkAsUploadedAsync(1, "fileId", 1);
 
             Assert.IsTrue(result.IsT1);
-            Assert.AreEqual(PostErrorModelHelper.ErrorPostNotFound(), result.AsT1);
+            Assert.AreEqual(PostErrorModelHelper.PostNotFoundError(), result.AsT1);
         }
 
         [TestMethod]
         public async Task MarkAsUploadedAsync_ShouldReturnMediaFileModel()
         {
             // Arrange
-            var post = new Post(1, 0) { Content = "Test content", Type = PostType.Event, Visibility = Visibility.Public };
+            var post = new Post(1) { Content = "Test content", Type = PostType.Event, Visibility = Visibility.Public };
             post.AddMediaFile(new MediaFile("fileId", "test.jpg", 1024, "application/jpg", MediaFile.ImageContainerName, "localhost"));
 
             var mediaFileModel = new MediaFileModel("test123", "test.jpg", "application/jpg", "localhost", true);
@@ -192,14 +182,14 @@ namespace HolaViaje.Social.Tests.Features.Posts
             var result = await _postApplication.DeleteMediaFileAsync(1, "fileId", 1);
 
             Assert.IsTrue(result.IsT1);
-            Assert.AreEqual(PostErrorModelHelper.ErrorPostNotFound(), result.AsT1);
+            Assert.AreEqual(PostErrorModelHelper.PostNotFoundError(), result.AsT1);
         }
 
         [TestMethod]
         public async Task DeleteMediaFileAsync_ShouldReturnMediaFileModel()
         {
             // Arrange
-            var post = new Post(1, 0) { Content = "Test content", Type = PostType.Event, Visibility = Visibility.Public };
+            var post = new Post(1) { Content = "Test content", Type = PostType.Event, Visibility = Visibility.Public };
             post.AddMediaFile(new MediaFile("fileId", "test.jpg", 1024, "application/jpg", MediaFile.ImageContainerName, "localhost"));
             var mediaFileModel = new MediaFileModel("test123", "test.jpg", "application/jpg", "localhost", true);
 
@@ -223,14 +213,14 @@ namespace HolaViaje.Social.Tests.Features.Posts
             var result = await _postApplication.DeleteAsync(1, 1);
 
             Assert.IsTrue(result.IsT1);
-            Assert.AreEqual(PostErrorModelHelper.ErrorPostNotFound(), result.AsT1);
+            Assert.AreEqual(PostErrorModelHelper.PostNotFoundError(), result.AsT1);
         }
 
         [TestMethod]
         public async Task DeleteAsync_ShouldReturnPostViewModel()
         {
             // Arrange
-            var post = new Post(1, 0) { Content = "Test content", Type = PostType.Event, Visibility = Visibility.Public };
+            var post = new Post(1) { Content = "Test content", Type = PostType.Event, Visibility = Visibility.Public };
             var postViewModel = new PostViewModel { Content = "Test content", Type = PostType.Event, Visibility = Visibility.Public, Control = new() };
 
             _postRepositoryMock.Setup(repo => repo.GetAsync(It.IsAny<long>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(post);
@@ -253,14 +243,14 @@ namespace HolaViaje.Social.Tests.Features.Posts
             var result = await _postApplication.GetAsync(1, 1);
 
             Assert.IsTrue(result.IsT1);
-            Assert.AreEqual(PostErrorModelHelper.ErrorPostNotFound(), result.AsT1);
+            Assert.AreEqual(PostErrorModelHelper.PostNotFoundError(), result.AsT1);
         }
 
         [TestMethod]
         public async Task GetAsync_ShouldReturnPostViewModel()
         {
             // Arrange
-            var post = new Post(1, 0) { Content = "Test content", Type = PostType.Event, Visibility = Visibility.Public };
+            var post = new Post(1) { Content = "Test content", Type = PostType.Event, Visibility = Visibility.Public };
             var postViewModel = new PostViewModel { Content = "Test content", Type = PostType.Event, Visibility = Visibility.Public, Control = new() };
 
             _postRepositoryMock.Setup(repo => repo.GetAsync(It.IsAny<long>(), false, It.IsAny<CancellationToken>())).ReturnsAsync(post);

--- a/test/HolaViaje.Social.Tests/Features/Posts/PostTests.cs
+++ b/test/HolaViaje.Social.Tests/Features/Posts/PostTests.cs
@@ -16,11 +16,10 @@ namespace HolaViaje.Social.Tests.Features.Posts
         }
 
         [TestMethod]
-        public void Constructor_WithParameters_ShouldSetUserIdAndPageId()
+        public void Constructor_WithParameters_ShouldSetUserId()
         {
-            var post = new Post(1, 2);
+            var post = new Post(1);
             Assert.AreEqual(1, post.UserId);
-            Assert.AreEqual(2, post.PageId);
         }
 
         [TestMethod]
@@ -99,15 +98,6 @@ namespace HolaViaje.Social.Tests.Features.Posts
             var post = new Post { UserId = 1 };
             Assert.IsTrue(post.IsOwner(1));
             Assert.IsFalse(post.IsOwner(2));
-        }
-
-        [TestMethod]
-        public void IsAssociatedWithPage_ShouldReturnTrueIfAssociated()
-        {
-            var post = new Post { PageId = 1 };
-            Assert.IsTrue(post.IsAssociatedWithPage());
-            post.PageId = 0;
-            Assert.IsFalse(post.IsAssociatedWithPage());
         }
 
         [TestMethod]


### PR DESCRIPTION
This commit removes the `PageId` property from `PostModel`, `Post`, and `PostApplication`, indicating a shift towards a model where posts are not directly tied to specific pages. The `PostErrorModelHelper` class has been updated to generalize error messages related to page permissions. Additionally, the `PostApplication` class has been refactored to simplify methods for post creation, updating, and deletion by eliminating page-related checks. Unit tests in `PostApplicationTests` and `PostTests` have also been updated to align with these changes, ensuring consistency in the new post model. Overall, this refactoring enhances the flexibility of the post management system.