### PR TITLE
Add media file upload functionality to posts

### DIFF
--- a/src/HolaViaje.Social/Features/Posts/IPostApplication.cs
+++ b/src/HolaViaje.Social/Features/Posts/IPostApplication.cs
@@ -34,6 +34,7 @@ public interface IPostApplication
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     Task<OneOf<PostViewModel, ErrorModel>> PublishAsync(long postId, long userId, CancellationToken cancellationToken = default);
+    Task<OneOf<MediaFileModel, ErrorModel>> UploadMediaFileAsync(long postId, UploadMediaFileModel model, long userId, CancellationToken cancellationToken = default);
     /// <summary>
     /// Creates an upload link for a media file.
     /// </summary>

--- a/src/HolaViaje.Social/Features/Posts/MediaFile.cs
+++ b/src/HolaViaje.Social/Features/Posts/MediaFile.cs
@@ -14,4 +14,7 @@ public record MediaFile(string FileId, string FileName, long FileSize, string Co
     public static readonly string VideoContainerName = "post-videos-1";
     public static readonly long VideoMaxSize = 1 * 1024 * 1024 * 1024;
     public static readonly string[] VideoValidExtensions = [".mp4", ".mov"];
+
+    public static readonly int MaxDirectUploadSize = 4 * 1024 * 1024;
+    public static readonly string[] ValidExtensions = ImageValidExtensions.Concat(VideoValidExtensions).ToArray();
 }

--- a/src/HolaViaje.Social/Features/Posts/Models/UploadMediaFileModel.cs
+++ b/src/HolaViaje.Social/Features/Posts/Models/UploadMediaFileModel.cs
@@ -1,0 +1,4 @@
+﻿
+namespace HolaViaje.Social.Features.Posts.Models;
+
+public record UploadMediaFileModel(string FileName, string ContentType, long FileSize, Stream FileStream) { }


### PR DESCRIPTION
- Updated `IPostApplication` with `UploadMediaFileAsync` method for handling media file uploads.
- Introduced `MaxDirectUploadSize` and `ValidExtensions` in `MediaFile` for upload validation.
- Implemented `UploadMediaFileAsync` in `PostApplication` to manage upload logic and validation.
- Added new endpoint in `PostController` for uploading media files with proper validation and response types.
- Enhanced `CreateUploadLinkAsync` to validate file properties and return appropriate status.
- Modified `MarkAsUploadedAsync` to return `200 OK` instead of `204 No Content`.
- Created `UploadMediaFileModel` to encapsulate media file upload properties.